### PR TITLE
Fix logical operator in rectangle check

### DIFF
--- a/common/src/utils/math-utils.js
+++ b/common/src/utils/math-utils.js
@@ -1,9 +1,9 @@
 class MathUtils {
   static isInRect(coordinates, rect){
     return coordinates.x >= rect.left
-            & coordinates.x <= rect.right
-            & coordinates.y >= rect.top
-            & coordinates.y <= rect.bottom;
+            && coordinates.x <= rect.right
+            && coordinates.y >= rect.top
+            && coordinates.y <= rect.bottom;
   }
 
   static computeRectCenter(rect){


### PR DESCRIPTION
## Summary
- Replace bitwise `&` with logical `&&` in `MathUtils.isInRect` so the method returns booleans.

## Testing
- `node -e "const fs=require('fs');const vm=require('vm');vm.runInThisContext(fs.readFileSync('./common/src/utils/math-utils.js','utf8'));console.log(MathUtils.isInRect({x:5,y:5},{left:0,right:10,top:0,bottom:10}));console.log(MathUtils.isInRect({x:15,y:5},{left:0,right:10,top:0,bottom:10}));"`


------
https://chatgpt.com/codex/tasks/task_e_68beb2138e7c832ba7bd219e2d98f865