### PR TITLE
Support multi-target number line trials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ number-to-line-task/res/videos/feedback/*.mp4
 
 TODO.*
 temp.*
+
+*.diff

--- a/config/number-to-line-task/minimal_debug.json
+++ b/config/number-to-line-task/minimal_debug.json
@@ -50,7 +50,8 @@
         {"targetString": "1/2", "mainInterval": 1, "graduationsPerUnit": 2, "flags": {"congruent": true}},
         {"targetString": "1/2", "mainInterval": 1, "graduationsPerUnit": 4, "flags": {"congruent": false}},
         {"targetString": "1/5", "mainInterval": 1, "graduationsPerUnit": 5, "flags": {"congruent": true}},
-        {"targetString": "1/2+1/2", "mainInterval": 1, "graduationsPerUnit": 2, "flags": {"congruent": true}}
+        {"targetString": "1/2+1/2", "mainInterval": 1, "graduationsPerUnit": 2, "flags": {"congruent": true}},
+        {"targetString": "1/4", "targetStrings": ["1/4", "3/4"], "mainInterval": 1, "graduationsPerUnit": 4, "flags": {"multiTarget": true}}
       ],
       "shuffleTest": true,
       "loopBelowSuccessThreshold": true,

--- a/config/number-to-line-task/minimal_debug.json
+++ b/config/number-to-line-task/minimal_debug.json
@@ -51,7 +51,7 @@
         {"targetString": "1/2", "mainInterval": 1, "graduationsPerUnit": 4, "flags": {"congruent": false}},
         {"targetString": "1/5", "mainInterval": 1, "graduationsPerUnit": 5, "flags": {"congruent": true}},
         {"targetString": "1/2+1/2", "mainInterval": 1, "graduationsPerUnit": 2, "flags": {"congruent": true}},
-        {"targetString": "1/4", "targetStrings": ["1/4", "3/4"], "mainInterval": 1, "graduationsPerUnit": 4, "flags": {"multiTarget": true}}
+        {"targetString": "", "targetStrings": ["1", "1/2", "1/4", "3/4"], "mainInterval": 1, "graduationsPerUnit": 4, "flags": {"multiTarget": true}}
       ],
       "shuffleTest": true,
       "loopBelowSuccessThreshold": true,

--- a/number-to-line-task/src/experiment-core.js
+++ b/number-to-line-task/src/experiment-core.js
@@ -154,12 +154,22 @@ class ExperimentCore {
   static formatTrialsData(trialData){
     let formattedData = JSON.parse(JSON.stringify(trialData));
 
-    let target = Rational.parse(formattedData.targetString)
-    formattedData.numberType = target.id;
+    let targetStrings = trialData.targetStrings ?? [trialData.targetString];
+    let parsedTargets = targetStrings.map(target => Rational.parse(target));
+
+    let primaryTarget = parsedTargets[0];
+    formattedData.numberType = primaryTarget.id;
     // TODO these two lines are deprecated
-    formattedData.numberFirstPart = target.components[0];
-    formattedData.numberSecondPart = target.components.length > 1 ? target.components[1] : -1;
-    formattedData.numberComponents = target.components
+    formattedData.numberFirstPart = primaryTarget.components[0];
+    formattedData.numberSecondPart = primaryTarget.components.length > 1 ? primaryTarget.components[1] : -1;
+    formattedData.numberComponents = primaryTarget.components;
+    formattedData.targetSequence = parsedTargets.map(target => ({
+      numberType: target.id,
+      components: target.components,
+      value: target.value,
+    }));
+    formattedData.targetStrings = targetStrings;
+    formattedData.targetString = targetStrings[0];
 
     // Handle graduations
     if (!Array.isArray(trialData.graduationsPerUnit))
@@ -169,6 +179,7 @@ class ExperimentCore {
     // Whatever will be saved!
     formattedData.flags = {
       targetString: trialData.targetString,
+      targetStrings: targetStrings,
       graduationsPerUnit: trialData.graduationsPerUnit,
       flags: trialData.flags
     }
@@ -185,6 +196,7 @@ class ExperimentCore {
       numberFirstPart: this.jsPsych.timelineVariable("numberFirstPart"),
       numberSecondPart: this.jsPsych.timelineVariable("numberSecondPart"),
       numberComponents: this.jsPsych.timelineVariable("numberComponents"),
+      targetSequence: this.jsPsych.timelineVariable("targetSequence"),
       majorGraduationInterval: this.jsPsych.timelineVariable("mainInterval"),
       minorGraduationInterval: this.jsPsych.timelineVariable("minorInterval"),
       useFeedback: isTraining ? config.feedback.correction.training : config.feedback.correction.test,

--- a/number-to-line-task/src/math/rational.js
+++ b/number-to-line-task/src/math/rational.js
@@ -31,6 +31,10 @@ class Rational{
   toImageNameWithDimensions(xSize, ySize, fractionImagePath = FRACTION_IMAGE_PATH){
     return fractionImagePath + this.toImageName() + `_${xSize}x${ySize}.png`;
   }
+
+  toDisplayString(){
+    return `${this.value}`;
+  }
 }
 
 class Fraction extends Rational{
@@ -45,6 +49,10 @@ class Fraction extends Rational{
 
   toImageName(){
     return `${this.numerator}_over_${this.denominator}`;
+  }
+
+  toDisplayString(){
+    return `${this.numerator}/${this.denominator}`;
   }
 
   decimalError(inverted, ten_value = 10){
@@ -71,6 +79,10 @@ class Decimal extends Rational{
   toImageName(){
     return `${this.wholePart}_comma_${this.decimalPart}`;
   }
+
+  toDisplayString(){
+    return `${this.wholePart}.${this.decimalPart}`;
+  }
 }
 
 class WholeNumber extends Rational{
@@ -82,6 +94,10 @@ class WholeNumber extends Rational{
   static REGEXPR = /^([0-9]+)$/
 
   toImageName(){
+    return `${this.value}`;
+  }
+
+  toDisplayString(){
     return `${this.value}`;
   }
 }
@@ -102,6 +118,10 @@ class FractionAddition extends Rational{
 
   toImageName(){
     return `${this.firstNumerator}_over_${this.firstDenominator}_plus_${this.secondNumerator}_over_${this.secondDenominator}`;
+  }
+
+  toDisplayString(){
+    return `${this.firstNumerator}/${this.firstDenominator}+${this.secondNumerator}/${this.secondDenominator}`;
   }
 }
 
@@ -144,6 +164,10 @@ class WholeOperation extends Rational{
 
   toImageName(){
     return `${this.firstTerm}_${this.sign == "+" ? "plus" : "minus"}_${this.secondTerm}`;
+  }
+
+  toDisplayString(){
+    return `${this.firstTerm}${this.sign}${this.secondTerm}`;
   }
 }
 
@@ -207,5 +231,11 @@ class WholeAndFractionOperation extends Rational{
     if (this.hasWholeNumberFirst)
       return `${this.wholeTerm}_${this.sign == "+" ? "plus" : "minus"}_${this.fractionNumerator}_over_${this.fractionDenominator}`;
     return `${this.fractionNumerator}_over_${this.fractionDenominator}_${this.sign == "+" ? "plus" : "minus"}_${this.wholeTerm}`;
+  }
+
+  toDisplayString(){
+    if (this.hasWholeNumberFirst)
+      return `${this.wholeTerm}${this.sign}${this.fractionNumerator}/${this.fractionDenominator}`;
+    return `${this.fractionNumerator}/${this.fractionDenominator}${this.sign}${this.wholeTerm}`;
   }
 }

--- a/number-to-line-task/src/plugin-number-to-line.js
+++ b/number-to-line-task/src/plugin-number-to-line.js
@@ -457,26 +457,32 @@ var numberToLine = (function (jspsych) {
         static createMouseClickedListener(trial, jsPsych){
           // Although `addEventListener` does not seem to care, we make the function async for convenience.
           return async function(e){
-            if(!trial.displayedStimulus || trial.answered)
+            if(!trial.displayedStimulus || trial.answered || trial.isProcessingResponse)
               return;
 
-            // Save position asap to avoid movement issues
-            let currentAnswerCoordinates = Cardboard.getCurrentCoordinates();
+            trial.isProcessingResponse = true;
 
-            // Loop in order of increasing priority
-            for (let priority in trial.info.responseElements){
-              for(let element of trial.info.responseElements[priority]){
-                // Ignore invisible elements
-                if(element.style.visibility == "hidden")
-                  continue
+            try {
+              // Save position asap to avoid movement issues
+              let currentAnswerCoordinates = Cardboard.getCurrentCoordinates();
 
-                // Stop if one element did react
-                if(NumberToLinePlugin.UI.Listeners.wasClicked(element, currentAnswerCoordinates)){
-                  await NumberToLinePlugin.Closing.handleResponseAndClose(
-                    element, currentAnswerCoordinates, trial, jsPsych)
-                  return;
+              // Loop in order of increasing priority
+              for (let priority in trial.info.responseElements){
+                for(let element of trial.info.responseElements[priority]){
+                  // Ignore invisible elements
+                  if(element.style.visibility == "hidden")
+                    continue
+
+                  // Stop if one element did react
+                  if(NumberToLinePlugin.UI.Listeners.wasClicked(element, currentAnswerCoordinates)){
+                    await NumberToLinePlugin.Closing.handleResponseAndClose(
+                      element, currentAnswerCoordinates, trial, jsPsych)
+                    return;
+                  }
                 }
               }
+            } finally {
+              trial.isProcessingResponse = false;
             }
           }
         }

--- a/number-to-line-task/src/plugin-number-to-line.js
+++ b/number-to-line-task/src/plugin-number-to-line.js
@@ -419,8 +419,7 @@ var numberToLine = (function (jspsych) {
     }
 
     static UI = class {
-      static ANSWER_CARDBOARD_HEIGHT_SCALE_BASE = 1.5;
-      static ANSWER_CARDBOARD_HEIGHT_SCALE_INCREMENT = 1.5;
+      static ANSWER_CARDBOARD_HEIGHT_SCALE_BASE = 1;
 
       static getNumericHeightPx(element, fallbackPx){
         let parseHeight = function(heightString){
@@ -925,6 +924,14 @@ var numberToLine = (function (jspsych) {
           }
         }
 
+        for (let element of archivedCardboard.querySelectorAll(
+          `#${Cardboard.PANEL_ID}-response-${responseIndex}, ` +
+          `#${Cardboard.HANDLE_ID}-response-${responseIndex}, ` +
+          `#${Cardboard.HANDLE_END_ID}-response-${responseIndex}`
+        )){
+          element.style.backgroundColor = GUI_CONFIG.CARDBOARD_BACKGROUND_COLOR;
+        }
+
         cardboard.parentNode?.insertBefore(archivedCardboard, cardboard);
 
         NumberToLinePlugin.UI.makeArchivedCardboardTaller(archivedCardboard, responseIndex);
@@ -959,9 +966,8 @@ var numberToLine = (function (jspsych) {
         let handleHeight = NumberToLinePlugin.UI.getNumericHeightPx(
           handleElement,
           Number.parseFloat(GUI_CONFIG.CARDBOARD_HANDLE_LENGTH));
-        let heightScale = NumberToLinePlugin.UI.ANSWER_CARDBOARD_HEIGHT_SCALE_BASE
-          + responseIndex * NumberToLinePlugin.UI.ANSWER_CARDBOARD_HEIGHT_SCALE_INCREMENT;
-        let extendedHandleHeight = handleHeight * heightScale;
+        let extendedHandleHeight = handleHeight
+          + responseIndex * panelHeight * NumberToLinePlugin.UI.ANSWER_CARDBOARD_HEIGHT_SCALE_BASE;
 
         handleElement.style.height = `${extendedHandleHeight}px`;
         let newCardboardHeight = panelHeight + extendedHandleHeight;

--- a/number-to-line-task/src/plugin-number-to-line.js
+++ b/number-to-line-task/src/plugin-number-to-line.js
@@ -862,6 +862,10 @@ var numberToLine = (function (jspsych) {
           cardboardDuplicateAnimation.play();
           cardboardAnimation.play();
           await cardboardAnimation.finished;
+
+          // Remove the duplicate to avoid duplicated element IDs interfering with
+          // subsequent cardboards (e.g., when another target is presented).
+          cardboardDuplicate.remove();
         }
 
         static async handleFeedback(answer, trial){

--- a/number-to-line-task/src/plugin-number-to-line.js
+++ b/number-to-line-task/src/plugin-number-to-line.js
@@ -454,7 +454,7 @@ var numberToLine = (function (jspsych) {
               panel.innerHTML = `<img src="${target.toImageNameWithDimensions(
                 trial.imageFileDimension,
                 trial.imageFileDimension,
-                FRACTION_IMAGE_PATH)}" alt="fraction">`;
+                FRACTION_IMAGE_PATH)}" alt="${target.toDisplayString()}">`;
               trial.displayedStimulus = true;
               break;
             case ExperimentCore.VERBAL_MODALITY:

--- a/number-to-line-task/src/plugin-number-to-line.js
+++ b/number-to-line-task/src/plugin-number-to-line.js
@@ -1107,6 +1107,12 @@ var numberToLine = (function (jspsych) {
           // Update the correct answer cache for the new target
           trial.correctAnswerOnCurrentLine = NumberToLinePlugin.Maths.computeCorrectAnswer(trial);
 
+          if (trial.endTimeout != undefined){
+            clearTimeout(trial.endTimeout);
+            trial.endTimeout = undefined;
+          }
+          NumberToLinePlugin.Closing.setTimeLimit(trial, jsPsych);
+
           if (trial.startOption == StartOptions.OPEN_CARDBOARD){
             let panel = document.getElementById(Cardboard.PANEL_ID);
             if (panel != null && typeof trial.displayStimulusFunction == "function")

--- a/number-to-line-task/src/plugin-number-to-line.js
+++ b/number-to-line-task/src/plugin-number-to-line.js
@@ -858,6 +858,29 @@ var numberToLine = (function (jspsych) {
         }
       }
 
+      static archiveCurrentCardboard(trial){
+        let cardboard = document.getElementById(Cardboard.FULL_DIV_ID);
+        if (cardboard == null)
+          return;
+
+        let responseIndex = Array.isArray(trial.responses) ? trial.responses.length : 0;
+        let archivedCardboard = cardboard.cloneNode(true);
+
+        archivedCardboard.id = `${Cardboard.FULL_DIV_ID}-response-${responseIndex}`;
+        archivedCardboard.style.pointerEvents = "none";
+        archivedCardboard.style.cursor = "auto";
+
+        for (let id of [Cardboard.PANEL_ID, Cardboard.HANDLE_ID, Cardboard.HANDLE_END_ID]){
+          let element = archivedCardboard.querySelector(`#${id}`);
+          if (element != null){
+            element.id = `${id}-response-${responseIndex}`;
+            element.style.cursor = "auto";
+          }
+        }
+
+        cardboard.parentNode?.insertBefore(archivedCardboard, cardboard);
+      }
+
       static handleSnap(trial, roundedAnswer){
         let cardboard = document.getElementById(Cardboard.FULL_DIV_ID);
 
@@ -1050,6 +1073,7 @@ var numberToLine = (function (jspsych) {
           // TODO investigate the copyTrial
           NumberToLinePlugin.Closing.finishTrial(jsPsych, trial, jsonUtils.copyTrial(trial), trial.afterTrialDelay)
         } else {
+          NumberToLinePlugin.UI.archiveCurrentCardboard(trial);
           NumberToLinePlugin.Progress.advanceToNextTarget(trial);
           NumberToLinePlugin.Progress.resetCardboardForNextTarget(trial);
 

--- a/number-to-line-task/src/plugin-number-to-line.js
+++ b/number-to-line-task/src/plugin-number-to-line.js
@@ -386,6 +386,8 @@ var numberToLine = (function (jspsych) {
         document.body.style.cursor = "auto";
 
         let cardboard = document.getElementById(Cardboard.FULL_DIV_ID);
+        let panel = document.getElementById(Cardboard.PANEL_ID);
+
         if (cardboard != null){
           HTML_UTILS.ReplaceBackgroundColour(cardboard,
             GUI_CONFIG.CARDBOARD_CORRECT_FEEDBACK_COLOUR,
@@ -396,9 +398,17 @@ var numberToLine = (function (jspsych) {
           HTML_UTILS.ReplaceBackgroundColour(cardboard,
             GUI_CONFIG.CARDBOARD_FROZEN_BACKGROUND_COLOR,
             GUI_CONFIG.CARDBOARD_BACKGROUND_COLOR);
+
+          NumberToLinePlugin.UI.resetCardboardPosition(cardboard);
+
+          let handle = document.getElementById(Cardboard.HANDLE_ID);
+          if (handle != null){
+            handle.style.height = GUI_CONFIG.CARDBOARD_HANDLE_LENGTH;
+            let panelHeight = panel?.style.height ?? GUI_CONFIG.CARDBOARD_PANEL_SIZE;
+            cardboard.style.height = `calc(${panelHeight} + ${handle.style.height})`;
+          }
         }
 
-        let panel = document.getElementById(Cardboard.PANEL_ID);
         if (panel != null)
           panel.innerHTML = "";
 
@@ -416,6 +426,21 @@ var numberToLine = (function (jspsych) {
           case BarRenderer.ID:
             return new BarRenderer(barColor, unitBackgroundColors);
         }
+      }
+
+      static getDefaultCardboardBottomPosition(){
+        return `calc(50vh
+            - (${GUI_CONFIG.CARDBOARD_PANEL_CENTER_FROM_VIEWPORT_CENTER})
+            - ${GUI_CONFIG.CARDBOARD_HANDLE_LENGTH}
+            - ${GUI_CONFIG.CARDBOARD_PANEL_SIZE} / 2)`;
+      }
+
+      static resetCardboardPosition(cardboardDiv){
+        cardboardDiv.style.left = "50%";
+        cardboardDiv.style.top = "";
+        cardboardDiv.style.bottom = NumberToLinePlugin.UI.getDefaultCardboardBottomPosition();
+        cardboardDiv.style.transformOrigin = "";
+        cardboardDiv.style.scale = 1;
       }
 
       static computeStimulusDisplayFunction(targetProvider, trial){
@@ -542,10 +567,7 @@ var numberToLine = (function (jspsych) {
             alreadyClicked,
             displayImmediately);
 
-          cardboardElement.style.bottom = `calc(50vh
-            - (${GUI_CONFIG.CARDBOARD_PANEL_CENTER_FROM_VIEWPORT_CENTER})
-            - ${GUI_CONFIG.CARDBOARD_HANDLE_LENGTH}
-            - ${GUI_CONFIG.CARDBOARD_PANEL_SIZE} / 2)`;
+          cardboardElement.style.bottom = NumberToLinePlugin.UI.getDefaultCardboardBottomPosition();
           return cardboardElement;
         }
 

--- a/number-to-line-task/src/plugin-number-to-line.js
+++ b/number-to-line-task/src/plugin-number-to-line.js
@@ -862,6 +862,7 @@ var numberToLine = (function (jspsych) {
           cardboardDuplicateAnimation.play();
           cardboardAnimation.play();
           await cardboardAnimation.finished;
+          cardboard.style.scale = 1;
 
           // Remove the duplicate to avoid duplicated element IDs interfering with
           // subsequent cardboards (e.g., when another target is presented).


### PR DESCRIPTION
## Summary
- allow number-to-line trials to receive a `targetSequence` and build multiple targets per stimulus
- update the plugin to cycle through targets, saving per-response data and resetting the UI between placements
- document the new capability in the debug configuration with a two-number example trial

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68f38f5bc5a4832bbec1de81f1878ba3